### PR TITLE
Remove trailing whitespace from pie directory

### DIFF
--- a/src/main/java/me/contaria/standardsettings/StandardGameOptions.java
+++ b/src/main/java/me/contaria/standardsettings/StandardGameOptions.java
@@ -93,7 +93,7 @@ public class StandardGameOptions extends GameOptions {
         if (!value.startsWith("root")) {
             value = "root";
         }
-        value = value.replace('.', '\u001e');
+        value = value.replace('.', '\u001e').strip();
         if (options instanceof StandardGameOptions) {
             ((StandardGameOptions) options).pieDirectory = value;
         } else {


### PR DESCRIPTION
Copy-paste seems to frequently add spaces to the end of pie directory which can be hard to detect. This helps me be lazier and may not benefit anyone else.