### PR TITLE
fix: trim whitespace from global filepath

### DIFF
--- a/src/main/java/me/contaria/standardsettings/StandardSettingsConfig.java
+++ b/src/main/java/me/contaria/standardsettings/StandardSettingsConfig.java
@@ -353,7 +353,7 @@ public class StandardSettingsConfig implements SpeedrunConfig {
         Path globalRedirect = SpeedrunConfigAPI.getConfigDir().resolve("standardsettings.global");
         if (Files.exists(globalRedirect)) {
             try {
-                File file = new File(new String(Files.readAllBytes(globalRedirect)));
+                File file = new File(new String(Files.readAllBytes(globalRedirect)).trim());
                 if (file.isFile()) {
                     return file;
                 }


### PR DESCRIPTION
On POSIX systems, text files are supposed to end with line breaks. Many text editors will uphold this rule and place a newline at the end of the `standardsettings.global` file. This prevents StandardSettings from loading the global JSON file, since it thinks the filepath ends with a line break when it shouldn't.

It might be better to read only the first line from the file or only remove trailing `\r` and `\n` characters? Feel free to let me know if you'd prefer this was implemented in a different way.