### PR TITLE
allow ctrl a backspace to clear pie directory widget

### DIFF
--- a/src/main/java/me/contaria/standardsettings/StandardSettingsConfig.java
+++ b/src/main/java/me/contaria/standardsettings/StandardSettingsConfig.java
@@ -217,9 +217,13 @@ public class StandardSettingsConfig implements SpeedrunConfig {
         this.register("pieDirectory", "f3", StandardGameOptions::getPieDirectory, StandardGameOptions::setPieDirectory, option -> new LiteralText(option.get()), option -> {
             TextFieldWidget widget = new TextFieldWidget(MinecraftClient.getInstance().textRenderer, 0, 0, 120, 20, option.getName());
             widget.setMaxLength(128);
-            widget.setTextPredicate(string -> string != null && string.startsWith("root"));
+            widget.setTextPredicate(string -> string != null && (string.startsWith("root") || string.isEmpty()));
             widget.setText(option.get());
             widget.setChangedListener(string -> {
+                if (string.isEmpty()) {
+                    widget.setText("root");
+                    return;
+                }
                 option.set(string);
                 for (String suggestion : new String[]{
                         "root.gameRenderer.level.entities",


### PR DESCRIPTION
ctrl x will still copy the whole block, but that can't be fixed without more invasive mixins
closes #18